### PR TITLE
Use openstacksdk <= 0.98.999

### DIFF
--- a/openstack/images/dib/requirements.txt
+++ b/openstack/images/dib/requirements.txt
@@ -1,2 +1,2 @@
 diskimage-builder==3.26.0
-openstacksdk==3.0.0
+openstacksdk<=0.98.999


### PR DESCRIPTION
Incompatible openstacksdk library found: Version MUST be >=0.36 and <=0.98.999, but 3.0.0 is larger than maximum version 0.98.999.