### PR TITLE
zuul: Use ansible 8 for os-ansible job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -62,6 +62,7 @@
     name: regiocloud-examples-os-ansible
     pre-run: openstack/ansible/pre.yml
     run: openstack/ansible/simple.yml
+    ansible-version: 8
     files:
       - '^.zuul.yaml$'
       - '^openstack\/ansible\/.*$'


### PR DESCRIPTION
Let's see whether the newer cloud collection is avoiding failures.